### PR TITLE
Add DCOM support for req command

### DIFF
--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -81,6 +81,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         action="store_true",
         help="Use Web Enrollment instead of RPC",
     )
+    connection_group.add_argument(
+        "-dcom",
+        action="store_true",
+        help="Use DCOM Enrollment instead of RPC",
+    )
 
     group = subparser.add_argument_group("rpc connection options")
     group.add_argument(


### PR DESCRIPTION
Added a -dcom switch for the req command to request a certificate via DCOM instead of plain RPC.
https://github.com/ly4k/Certipy/pull/201